### PR TITLE
Prevent keyword truncation

### DIFF
--- a/lib/MigratorUtil.php
+++ b/lib/MigratorUtil.php
@@ -34,8 +34,11 @@ class MigratorUtil
                 break;
             }
 
-            $buffer .= fread($fp, 512);
-            $tokens = token_get_all($buffer);
+            // Read entire lines to prevent keyword truncation
+            for ($line = 0; $line <= 20; $line++) {
+                $buffer .= fgets($fp);
+            }
+            $tokens = @token_get_all($buffer);
 
             if (strpos($buffer, '{') === false) {
                 continue;

--- a/tests/Unit/MigratorUtilTest.php
+++ b/tests/Unit/MigratorUtilTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the PHPCR Migrations package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPCR\Migrations\tests\Unit;
+
+use PHPCR\Migrations\MigratorUtil;
+
+class MigratorUtilTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * It should return the classname of a file.
+     */
+    public function testGetClassName()
+    {
+        $className = MigratorUtil::getClassNameFromFile(__DIR__ . '/migrations/Version201511240843.php');
+        $this->assertEquals('\Sulu\Bundle\ContentBundle\Version201511240843', $className);
+    }
+}

--- a/tests/Unit/migrations/Version201511240843.php
+++ b/tests/Unit/migrations/Version201511240843.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the PHPCR Migrations package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sulu\Bundle\ContentBundle;
+
+use PHPCR\Migrations\VersionInterface;
+use PHPCR\NodeInterface;
+use PHPCR\SessionInterface;
+use Bala\Bundle\ContentBundle\Blog\BasePageBlog;
+use Bala\Bundle\BlogManagerBundle\Bridge\BlogInspector;
+use Bala\Bundle\BlogManagerBundle\Bridge\PropertyEncoder;
+use Bala\Component\Content\Metadata\BlockMetadata;
+use Bala\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
+use Bala\Component\Content\Metadata\PropertyMetadata;
+use Bala\Component\Content\Metadata\StructureMetadata;
+use Bala\Component\BlogManager\BlogManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+ *
+ * Created: 2015-12-10 10:04
+ */
+class Version201511240843 implements VersionInterface, ContainerAwareInterface
+{
+}


### PR DESCRIPTION
Prevent keyword truncation (and Warnings) when determining the class
contained in a file.

The original code read 512 character chunks from the file, but this meant that keywords could be truncated.

This fix only reads entire lines.
