### PR TITLE
Allow PHP 8 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.lock
 vendor
 tests/data
 tests/migrations
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: php
 php:
   - 5.6
   - 7.1
+  - 7.2
+  - 7.3
 
 env:
   - PACKAGE_VERSION=high
@@ -13,10 +15,15 @@ matrix:
   include:
     - php: 5.6
       env: PACKAGE_VERSION=low
+    - php: 7.4
+      env:
+          - MINIMUM_STABILITY=dev
+          - PACKAGE_VERSION=high
 
 before_script:
   - composer selfupdate
+  - if [[ "$MINIMUM_STABILITY" ]]; then composer config minimum-stability $MINIMUM_STABILITY ; fi
   - if [[ "$PACKAGE_VERSION" == "high" ]]; then composer update --prefer-dist; fi
   - if [[ "$PACKAGE_VERSION" == "low" ]]; then composer update --prefer-lowest --prefer-dist; fi
 
-script: vendor/bin/phpunit
+script: vendor/bin/simple-phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ matrix:
       env:
           - MINIMUM_STABILITY=dev
           - PACKAGE_VERSION=high
+    - php: nightly
+      env:
+          - MINIMUM_STABILITY=dev
+          - PACKAGE_VERSION=high
 
 before_script:
   - composer selfupdate

--- a/composer.json
+++ b/composer.json
@@ -9,14 +9,14 @@
         }
     ],
     "require": {
-        "phpcr/phpcr": "~2.1",
-        "symfony/finder": "~2.8 || ~3.4 || ~4.0",
-        "symfony/console": "~2.8 || ~3.4 || ~4.0"
+        "phpcr/phpcr": "^2.1",
+        "symfony/finder": "^2.8 || ^3.4 || ^4.0 || ^5.0",
+        "symfony/console": "^2.8 || ^3.4 || ^4.0 || ^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7",
-        "jackalope/jackalope-fs": "dev-master",
-        "zendframework/zendsearch": "@dev"
+        "symfony/phpunit-bridge": "^5.0.4",
+        "jackalope/jackalope-fs": "0.0.*",
+        "handcraftedinthealps/zendsearch": "^2.0"
     },
     "autoload": {
         "psr-4": {
@@ -29,6 +29,6 @@
         }
     },
     "extra": {
-        "branch-alias": {"dev-master": "1.0-dev" }
+        "branch-alias": {"dev-master": "1.x-dev" }
     }
 }

--- a/lib/MigratorUtil.php
+++ b/lib/MigratorUtil.php
@@ -47,7 +47,9 @@ class MigratorUtil
             for (;$i < count($tokens);$i++) {
                 if ($tokens[$i][0] === T_NAMESPACE) {
                     for ($j = $i + 1;$j < count($tokens); $j++) {
-                        if ($tokens[$j][0] === T_STRING) {
+                        if (\defined('T_NAME_QUALIFIED') && $tokens[$j][0] === T_NAME_QUALIFIED) {
+                            $namespace .= '\\' . $tokens[$j][1];
+                        } elseif ($tokens[$j][0] === T_STRING) {
                             $namespace .= '\\' . $tokens[$j][1];
                         } elseif ($tokens[$j] === '{' || $tokens[$j] === ';') {
                             break;

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,11 @@
     colors="true"
     bootstrap="vendor/autoload.php"
     >
+    <php>
+        <env name="SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT" value="1"/>
+        <env name="SYMFONY_PHPUNIT_REMOVE" value="symfony/yaml"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled=1"/>
+    </php>
 
     <testsuites>
         <testsuite name="PHPCR migrations Test Suite">

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -13,9 +13,10 @@ namespace PHPCR\Migrations;
 
 use Jackalope\RepositoryFactoryFilesystem;
 use PHPCR\SimpleCredentials;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
-class BaseTestCase extends \PHPUnit_Framework_TestCase
+class BaseTestCase extends TestCase
 {
     protected $session;
 

--- a/tests/Functional/MigrationTest.php
+++ b/tests/Functional/MigrationTest.php
@@ -12,6 +12,7 @@
 namespace PHPCR\Migrations\tests\Functional;
 
 use PHPCR\Migrations\BaseTestCase;
+use PHPCR\Migrations\Exception\MigratorException;
 use PHPCR\Migrations\Migrator;
 use PHPCR\Migrations\VersionFinder;
 use PHPCR\Migrations\VersionStorage;
@@ -161,15 +162,16 @@ class MigrationTest extends BaseTestCase
 
     /**
      * It should throw an exception if trying to reiniitialize.
-     *
-     * @expectedException PHPCR\Migrations\Exception\MigratorException
-     * @expectedExceptionMessage Will not re-initialize
      */
     public function testReinitialize()
     {
         $this->addVersion(self::VERSION1);
         $this->addVersion(self::VERSION2);
+
         $this->getMigrator()->initialize();
+
+        $this->expectException(MigratorException::class);
+        $this->expectExceptionMessage('Will not re-initialize');
         $this->getMigrator()->initialize();
     }
 

--- a/tests/Unit/MigratorFactoryTest.php
+++ b/tests/Unit/MigratorFactoryTest.php
@@ -17,8 +17,9 @@ use PHPCR\Migrations\VersionCollection;
 use PHPCR\Migrations\VersionFinder;
 use PHPCR\Migrations\VersionStorage;
 use PHPCR\SessionInterface;
+use PHPUnit\Framework\TestCase;
 
-class MigratorFactoryTest extends \PHPUnit_Framework_TestCase
+class MigratorFactoryTest extends TestCase
 {
     public function testFactory()
     {

--- a/tests/Unit/MigratorUtilTest.php
+++ b/tests/Unit/MigratorUtilTest.php
@@ -12,8 +12,9 @@
 namespace PHPCR\Migrations\tests\Unit;
 
 use PHPCR\Migrations\MigratorUtil;
+use PHPUnit\Framework\TestCase;
 
-class MigratorUtilTest extends \PHPUnit_Framework_TestCase
+class MigratorUtilTest extends TestCase
 {
     /**
      * It should return the classname of a file.

--- a/tests/Unit/VersionCollectionTest.php
+++ b/tests/Unit/VersionCollectionTest.php
@@ -13,8 +13,9 @@ namespace PHPCR\Migrations\tests\Unit;
 
 use PHPCR\Migrations\VersionCollection;
 use PHPCR\Migrations\VersionInterface;
+use PHPUnit\Framework\TestCase;
 
-class VersionCollectionTest extends \PHPUnit_Framework_TestCase
+class VersionCollectionTest extends TestCase
 {
     const VERSION1 = '201501010000';
     const VERSION2 = '201501020000';

--- a/tests/Unit/VersionFinderTest.php
+++ b/tests/Unit/VersionFinderTest.php
@@ -13,8 +13,9 @@ namespace PHPCR\Migrations\tests\Unit;
 
 use PHPCR\Migrations\VersionCollection;
 use PHPCR\Migrations\VersionFinder;
+use PHPUnit\Framework\TestCase;
 
-class VersionFinderTest extends \PHPUnit_Framework_TestCase
+class VersionFinderTest extends TestCase
 {
     public function setUp()
     {
@@ -38,13 +39,11 @@ class VersionFinderTest extends \PHPUnit_Framework_TestCase
 
     /**
      * It should do nothing if no migrations paths are given.
-     *
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage No paths were provided
      */
     public function testNoMigrationPaths()
     {
-        $collection = (new VersionFinder(array()))->getCollection();
-        $versions = $collection->getAllVersions();
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('No paths were provided');
+        $versionFinder = new VersionFinder(array());
     }
 }


### PR DESCRIPTION
In PHP 8 namespaces are treated as single token (T_NAME_FULLY_QUALIFIED)

RFC: [https://wiki.php.net/rfc/namespaced_names_as_token](https://wiki.php.net/rfc/namespaced_names_as_token)

This PR add compatibility with this token