### PR TITLE
Allow PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 5.6
-  - 7.1
   - 7.2
   - 7.3
 
@@ -13,12 +11,14 @@ sudo: false
 
 matrix:
   include:
-    - php: 5.6
-      env: PACKAGE_VERSION=low
     - php: 7.4
       env:
           - MINIMUM_STABILITY=dev
           - PACKAGE_VERSION=high
+    - php: nightly
+      env:
+        - MINIMUM_STABILITY=dev
+        - PACKAGE_VERSION=high
 
 before_script:
   - composer selfupdate
@@ -26,4 +26,4 @@ before_script:
   - if [[ "$PACKAGE_VERSION" == "high" ]]; then composer update --prefer-dist; fi
   - if [[ "$PACKAGE_VERSION" == "low" ]]; then composer update --prefer-lowest --prefer-dist; fi
 
-script: vendor/bin/simple-phpunit
+script: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -9,14 +9,15 @@
         }
     ],
     "require": {
+        "php": "^7.2|^8.0",
         "phpcr/phpcr": "^2.1",
-        "symfony/finder": "^2.8 || ^3.4 || ^4.0 || ^5.0",
-        "symfony/console": "^2.8 || ^3.4 || ^4.0 || ^5.0"
+        "symfony/finder": "^4.4 || ^5.0",
+        "symfony/console": "^4.4 || ^5.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^5.0.4",
         "jackalope/jackalope-fs": "0.0.*",
-        "handcraftedinthealps/zendsearch": "^2.0"
+        "handcraftedinthealps/zendsearch": "^2.0",
+        "phpunit/phpunit": "^8.5 || ^9.4"
     },
     "autoload": {
         "psr-4": {
@@ -25,7 +26,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "PHPCR\\Migrations\\": "tests"
+            "PHPCR\\Migrations\\Tests\\": "tests"
         }
     },
     "extra": {

--- a/lib/Migrator.php
+++ b/lib/Migrator.php
@@ -62,12 +62,8 @@ class Migrator
      *
      * @return VersionInterface[] Executed migrations
      */
-    public function migrate($to = null, OutputInterface $output)
+    public function migrate(?string $to, OutputInterface $output)
     {
-        if (false === $to) {
-            return array();
-        }
-
         $from = $this->versionStorage->getCurrentVersion();
         $to = $this->resolveTo($to, $from);
 
@@ -79,7 +75,6 @@ class Migrator
             return array();
         }
 
-        $start = microtime(true);
         $position = 0;
         $output->writeln(sprintf('<comment>%s</comment> %d version(s):', ($direction == 'up' ? 'Upgrading' : 'Reverting'), count($versionsToExecute)));
         foreach ($versionsToExecute as $timestamp => $version) {

--- a/lib/Migrator.php
+++ b/lib/Migrator.php
@@ -57,12 +57,12 @@ class Migrator
      * If $to is 0 then all migrations will be reverted.
      * If $to is null then all migrations will be executed.
      *
-     * @param string $to Version to run until
+     * @param string|null $to Version to run until
      * @param OutputInterface $output
      *
      * @return VersionInterface[] Executed migrations
      */
-    public function migrate(?string $to, OutputInterface $output)
+    public function migrate($to, OutputInterface $output)
     {
         $from = $this->versionStorage->getCurrentVersion();
         $to = $this->resolveTo($to, $from);

--- a/lib/MigratorUtil.php
+++ b/lib/MigratorUtil.php
@@ -47,7 +47,9 @@ class MigratorUtil
             for (;$i < count($tokens);$i++) {
                 if ($tokens[$i][0] === T_NAMESPACE) {
                     for ($j = $i + 1;$j < count($tokens); $j++) {
-                        if ($tokens[$j][0] === T_STRING) {
+                        if (\defined('T_NAME_QUALIFIED') && $tokens[$j][0] === T_NAME_QUALIFIED) {
+                            $namespace .= '\\' . $tokens[$j][1];
+                        } elseif ($tokens[$j][0] === T_STRING) {
                             $namespace .= '\\' . $tokens[$j][1];
                         } elseif ($tokens[$j] === '{' || $tokens[$j] === ';') {
                             break;

--- a/lib/VersionFinder.php
+++ b/lib/VersionFinder.php
@@ -11,6 +11,7 @@
 
 namespace PHPCR\Migrations;
 
+use PHPCR\Migrations\Exception\MigratorException;
 use Symfony\Component\Finder\Finder;
 
 class VersionFinder

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,7 @@
     </testsuites>
 
     <filter>
+
         <whitelist addUncoveredFilesFromWhitelist="true">
             <directory>.</directory>
             <exclude>

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace PHPCR\Migrations;
+namespace PHPCR\Migrations\Tests;
 
 use Jackalope\RepositoryFactoryFilesystem;
 use PHPCR\SimpleCredentials;

--- a/tests/Functional/MigrationTest.php
+++ b/tests/Functional/MigrationTest.php
@@ -9,11 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace PHPCR\Migrations\tests\Functional;
+namespace PHPCR\Migrations\Tests\Functional;
 
-use PHPCR\Migrations\BaseTestCase;
 use PHPCR\Migrations\Exception\MigratorException;
 use PHPCR\Migrations\Migrator;
+use PHPCR\Migrations\Tests\BaseTestCase;
 use PHPCR\Migrations\VersionFinder;
 use PHPCR\Migrations\VersionStorage;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -27,10 +27,11 @@ class MigrationTest extends BaseTestCase
 
     private $output;
     private $filesystem;
+    private $migrationDistDir;
     private $migrationDir;
     private $storage;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->initPhpcr();
         $this->migrationDir = __DIR__ . '/../migrations';
@@ -63,9 +64,9 @@ class MigrationTest extends BaseTestCase
         $nodes = $this->session->getNode('/phpcrmig:versions')->getNodes();
         $names = array_keys((array) $nodes);
 
-        $this->assertContains('201501011200', $names);
-        $this->assertContains('201501011212', $names);
-        $this->assertContains('201501011215', $names);
+        $this->assertContains(201501011200, $names);
+        $this->assertContains(201501011212, $names);
+        $this->assertContains(201501011215, $names);
     }
 
     /**
@@ -201,6 +202,7 @@ class MigrationTest extends BaseTestCase
         $this->addVersion(self::VERSION2);
         $this->addVersion(self::VERSION3);
         $migratedVersions = $this->getMigrator()->migrate(null, $this->output);
+        $this->assertCount(3, $migratedVersions);
         $this->assertEquals(self::VERSION3, $this->storage->getCurrentVersion());
 
         $migratedVersions = $this->getMigrator()->migrate('down', $this->output);
@@ -256,8 +258,7 @@ class MigrationTest extends BaseTestCase
         $this->storage = new VersionStorage($this->session);
         $finder = new VersionFinder(array($this->migrationDir));
         $versions = $finder->getCollection();
-        $migrator = new Migrator($this->session, $versions, $this->storage);
 
-        return $migrator;
+        return new Migrator($this->session, $versions, $this->storage);
     }
 }

--- a/tests/Unit/MigratorFactoryTest.php
+++ b/tests/Unit/MigratorFactoryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace PHPCR\Migrations\tests\Unit;
+namespace PHPCR\Migrations\Tests\Unit;
 
 use PHPCR\Migrations\Migrator;
 use PHPCR\Migrations\MigratorFactory;
@@ -18,6 +18,7 @@ use PHPCR\Migrations\VersionFinder;
 use PHPCR\Migrations\VersionStorage;
 use PHPCR\SessionInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class MigratorFactoryTest extends TestCase
 {

--- a/tests/Unit/MigratorUtilTest.php
+++ b/tests/Unit/MigratorUtilTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace PHPCR\Migrations\tests\Unit;
+namespace PHPCR\Migrations\Tests\Unit;
 
 use PHPCR\Migrations\MigratorUtil;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/VersionCollectionTest.php
+++ b/tests/Unit/VersionCollectionTest.php
@@ -9,11 +9,12 @@
  * file that was distributed with this source code.
  */
 
-namespace PHPCR\Migrations\tests\Unit;
+namespace PHPCR\Migrations\Tests\Unit;
 
 use PHPCR\Migrations\VersionCollection;
 use PHPCR\Migrations\VersionInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class VersionCollectionTest extends TestCase
 {
@@ -21,7 +22,7 @@ class VersionCollectionTest extends TestCase
     const VERSION2 = '201501020000';
     const VERSION3 = '201501030000';
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->version1 = $this->prophesize('PHPCR\Migrations\VersionInterface');
         $this->version2 = $this->prophesize('PHPCR\Migrations\VersionInterface');

--- a/tests/Unit/VersionFinderTest.php
+++ b/tests/Unit/VersionFinderTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace PHPCR\Migrations\tests\Unit;
+namespace PHPCR\Migrations\Tests\Unit;
 
 use PHPCR\Migrations\VersionCollection;
 use PHPCR\Migrations\VersionFinder;
@@ -17,7 +17,12 @@ use PHPUnit\Framework\TestCase;
 
 class VersionFinderTest extends TestCase
 {
-    public function setUp()
+    /**
+     * @var VersionFinder
+     */
+    private $finder;
+
+    public function setUp(): void
     {
         $this->finder = new VersionFinder(array(
             __DIR__ . '/../migrations',


### PR DESCRIPTION
In PHP 8 namespaces are treated as single token (T_NAME_FULLY_QUALIFIED)

RFC: https://wiki.php.net/rfc/namespaced_names_as_token

This PR add compatibility with this token