### PR TITLE
Symfony 6 support

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -22,6 +22,7 @@ jobs:
                     - php-version: '7.3'
                     - php-version: '7.4'
                     - php-version: '8.0'
+                    - php-version: '8.1'
 
         steps:
             - name: Checkout project

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     "require": {
         "php": "^7.2|^8.0",
         "phpcr/phpcr": "^2.1",
-        "symfony/finder": "^4.4 || ^5.0",
-        "symfony/console": "^4.4 || ^5.0"
+        "symfony/finder": "^4.4 || ^5.0 || ^6.0",
+        "symfony/console": "^4.4 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "jackalope/jackalope-fs": "0.0.*",


### PR DESCRIPTION
- allowed symfony 6 in version constraints
- added ci-config for php 8.1

requires:
- https://github.com/jackalope/jackalope-fs/pull/29