### PR TITLE
Fixing the parsing of class names

### DIFF
--- a/lib/MigratorUtil.php
+++ b/lib/MigratorUtil.php
@@ -56,6 +56,11 @@ class MigratorUtil
                 }
 
                 if ($tokens[$i][0] === T_CLASS) {
+                    // If we have something like Test::class, we want to ignore that
+                    if (($tokens[$i - 1][1] ?? '') === '::') {
+                        continue;
+                    }
+
                     for ($j = $i + 1;$j < count($tokens);$j++) {
                         if ($tokens[$j] === '{') {
                             $class = $tokens[$i + 2][1];

--- a/tests/Unit/MigratorUtilTest.php
+++ b/tests/Unit/MigratorUtilTest.php
@@ -24,4 +24,12 @@ class MigratorUtilTest extends TestCase
         $className = MigratorUtil::getClassNameFromFile(__DIR__ . '/migrations/Version201511240843.php');
         $this->assertEquals('\Sulu\Bundle\ContentBundle\Version201511240843', $className);
     }
+
+    /**
+     * It should not be confused by ::class in a file
+     */
+    public function testGetClassNameWithClassElsewhere() {
+        $className = MigratorUtil::getClassNameFromFile(__DIR__ . '/migrations/Version201712120843.php');
+        $this->assertEquals('\Sulu\Bundle\ContentBundle\Version201712120843', $className);
+    }
 }

--- a/tests/Unit/migrations/Version201712120843.php
+++ b/tests/Unit/migrations/Version201712120843.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the PHPCR Migrations package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sulu\Bundle\ContentBundle;
+
+use PHPCR\Migrations\VersionInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+
+/**
+ * Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+ *
+ * Created: 2015-12-10 10:04
+ */
+class Version201712120843 implements VersionInterface, ContainerAwareInterface
+{
+    public function someFunction(): string {
+        return self::class;
+    }
+
+    public function someOtherFunctionWeNeedForMoreConfustion() {
+
+    }
+}


### PR DESCRIPTION
## Why?
The old version of the parser was looking for the class keyword followed by a `{`. The problem is the parser doesn't take into account that the class keyword can also be used in a different context like in `self::class` which then will crash because if you have something like expression like 
```
$a = (self::class);
{
}
```
this it will take the token that is two after the class keyword which in this case would be the semicolon. Which is not correct.

## What?
I have added a check that if the token preceding the class keyword is the '::' operator, then it will skip it. (It's not a good fix though).

## Further things to consider
* Maybe return after finding the first instance of the class keyword (however this would change the behavior as we are currently taking the last class in the file
* What about anonymous classes inside the migration? This will also break the code